### PR TITLE
`marginal_for_startup_rank` enables use of marginal cost rather than …

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -37,6 +37,11 @@ What's New?
 *  :class:`.DispatchModel` now accepts ``dispatchable_cost`` with monthly frequency.
 *  Added :meth:`.DispatchModel.set_metadata` to safely set metadata.
    :meth:`.DispatchModel.__getattr__` allows retrieving metadata using attribute access.
+*  Added ``marginal_for_startup_rank`` flag to :func:`.dispatch_engine` and
+   :class:`.DispatchModel` ``config`` to use marginal cost rank to order generators for
+   startup rather than startup cost. Given costs from :mod:`rmi.gencost` have very low
+   startup cost relative to marginal costs, marginal costs can be a better metric for
+   committing units.
 
 Bug Fixes
 ^^^^^^^^^

--- a/src/dispatch/model.py
+++ b/src/dispatch/model.py
@@ -62,7 +62,10 @@ class DispatchModel(IOMixin):
         "_metadata",
         "_cached",
     )
-    default_config: ClassVar[dict[str, str]] = {"dynamic_reserve_coeff": "auto"}
+    default_config: ClassVar[dict[str, str | bool]] = {
+        "dynamic_reserve_coeff": "auto",
+        "marginal_for_startup_rank": False,
+    }
 
     def __init__(
         self,
@@ -744,7 +747,8 @@ class DispatchModel(IOMixin):
         if np.any(to_exclude == 0.0):
             d_prof = d_prof * to_exclude
 
-        coeff = (self.config | kwargs)["dynamic_reserve_coeff"]
+        config = self.config | kwargs
+        coeff = config["dynamic_reserve_coeff"]
 
         if self._metadata["jit"]:
             func = dispatch_engine_auto
@@ -794,6 +798,7 @@ class DispatchModel(IOMixin):
             storage_dc_charge=self.dc_charge().to_numpy(dtype=np.float_),
             storage_reserve=self.storage_specs.reserve.to_numpy(),
             dynamic_reserve_coeff=coeff,
+            marginal_for_startup_rank=config["marginal_for_startup_rank"],
         )
         self.redispatch = pd.DataFrame(
             fos_prof,

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -58,6 +58,22 @@ def test_redispatch_total(ent_dm, attr, expected):
     assert getattr(ent_dm, attr).sum().sum() == pytest.approx(expected[ind])
 
 
+@pytest.mark.parametrize(
+    ("attr", "expected"),
+    [
+        ("redispatch", {"f": 399_164_260, "r": 370_199_520}),
+        ("storage_dispatch", {"f": 263_867_618, "r": 232_788_258}),
+        ("system_data", {"f": 50_259_729, "r": 76_623_300}),
+    ],
+    ids=idfn,
+)
+def test_redispatch_marginal_for_startup_rank_total(ent_dm, attr, expected):
+    """High-level test of marginal_for_startup_rank that results have not changed."""
+    ind, ent_dm = ent_dm
+    ent_dm = ent_dm(marginal_for_startup_rank=True)
+    assert getattr(ent_dm, attr).sum().sum() == pytest.approx(expected[ind])
+
+
 @pytest.mark.parametrize("comparison", [None, "load_max"], ids=idfn)
 def test_low_lost_load(mini_dm, comparison):
     """Dummy test that there isn't much lost load."""


### PR DESCRIPTION
…startup cost to order generators for startup